### PR TITLE
fix get_facts for switches that dont support output modifiers

### DIFF
--- a/napalm_s350/utils/textfsm_templates/hosts.tpl
+++ b/napalm_s350/utils/textfsm_templates/hosts.tpl
@@ -1,0 +1,8 @@
+Value DOMAIN_NAME ([\w+.]+)
+
+Start
+  ^\s+Domain\s+Source\s+Interface\s+Preference -> Domains
+  ^\s+Source\s+Interface\s+Preference\s+Domain -> Domains
+
+Domains
+  ^${DOMAIN_NAME} -> Record End


### PR DESCRIPTION
Some versions of SG3XX do not support output modifiers e.g. "|".

```
switch02#show version | include Version
% Wrong number of parameters or invalid range, size or characters entered
```

```
switch02#show inventory 
NAME: "1"   DESCR: "SG300-28 28-Port Gigabit Managed Switch"   
PID: SRW2024-K9   VID: V04   SN: <removed> 
```
This pull request modifies get_facts to pull information without relying on piping. 
