### PR TITLE
adding read_timeout_override and session_log optional_args for netmiko

### DIFF
--- a/napalm_s350/s350.py
+++ b/napalm_s350/s350.py
@@ -77,6 +77,7 @@ class S350Driver(NetworkDriver):
             "alt_key_file": "",
             "ssh_config_file": None,
             "allow_agent": False,
+            "session_log": None,
             "read_timeout_override": None,
         }
 

--- a/napalm_s350/s350.py
+++ b/napalm_s350/s350.py
@@ -77,6 +77,7 @@ class S350Driver(NetworkDriver):
             "alt_key_file": "",
             "ssh_config_file": None,
             "allow_agent": False,
+            "read_timeout_override": None,
         }
 
         # Allow for passing additional Netmiko arguments


### PR DESCRIPTION
Similar to https://github.com/napalm-automation-community/napalm-s350/pull/82 but adding the `optional_args` instead.

